### PR TITLE
Fix refresh token duplication on login

### DIFF
--- a/src/main/java/com/AuthService/Auth_Service/Controllers/ResponseTokenController.java
+++ b/src/main/java/com/AuthService/Auth_Service/Controllers/ResponseTokenController.java
@@ -38,11 +38,14 @@ public class ResponseTokenController {
     public ResponseEntity AuthenticateAndGetToken(@Valid @RequestBody AuthRequestDTO authRequestDTO) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(authRequestDTO.getUsername(), authRequestDTO.getPassword()));
+        System.out.println("authentication");
         if (authentication.isAuthenticated()) {
-            RefreshToken refreshToken = refreshTokenService.createRefreshToken(authRequestDTO.getUsername());
+            // RefreshToken refreshToken =
+            // refreshTokenService.createRefreshToken(authRequestDTO.getUsername());
+            // System.out.println("Token Created:" + refreshToken.toString());
             return new ResponseEntity<>(JwtResponseDto.builder()
                     .accessToken(jwtService.GenerateToken(authRequestDTO.getUsername()))
-                    .token(refreshToken.getToken())
+                    .token(refreshTokenService.getOrCreateRefreshToken(authRequestDTO.getUsername()).getToken())
                     .build(), HttpStatus.OK);
 
         } else {

--- a/src/main/java/com/AuthService/Auth_Service/Entities/RefreshToken.java
+++ b/src/main/java/com/AuthService/Auth_Service/Entities/RefreshToken.java
@@ -33,7 +33,7 @@ public class RefreshToken {
     private String token;
     private Instant expiryDate;
     @OneToOne
-    @JoinColumn(name = "tokenid", referencedColumnName = "user_id")
+    @JoinColumn(name = "username", referencedColumnName = "user_id")
     private Userinfo userinfo;
 
 }

--- a/src/main/java/com/AuthService/Auth_Service/Repository/TokenRefreshRepo.java
+++ b/src/main/java/com/AuthService/Auth_Service/Repository/TokenRefreshRepo.java
@@ -11,4 +11,6 @@ import com.AuthService.Auth_Service.Entities.RefreshToken;
 public interface TokenRefreshRepo extends CrudRepository<RefreshToken, Integer> {
     Optional<RefreshToken> findByToken(String token);
 
+    Optional<RefreshToken> findByUserinfo_Username(String username);
+
 }

--- a/src/main/java/com/AuthService/Auth_Service/Services/RefreshTokenService.java
+++ b/src/main/java/com/AuthService/Auth_Service/Services/RefreshTokenService.java
@@ -44,4 +44,9 @@ public class RefreshTokenService {
         }
         return token;
     }
+
+    public RefreshToken getOrCreateRefreshToken(String username) {
+        return refreshTokenService.findByUserinfo_Username(username)
+                .orElseGet(() -> createRefreshToken(username));
+    }
 }


### PR DESCRIPTION
## 🛠️ Fix refresh token duplication on login

### Summary
This commit fixes a bug where logging in multiple times with the same user would attempt to create a new refresh token each time, violating the unique constraint in the database.

### Root Cause
- The system was generating a refresh token on every login, regardless of whether one already existed.
- Additionally, the repository method `findByUsername(String username)` failed since `username` is not a direct field of the `RefreshToken` entity but part of a mapped `userinfo` entity.

### What I Changed
- Updated `TokenRefreshRepo` to use:  
  ```java
  Optional<RefreshToken> findByUserinfo_Username(String username);
  
 **Note:- Spring Data JPA could not map username directly, causing the application to fail on startup.**
  
 **What I Learned?**
How to traverse nested fields in Spring Data JPA using the _ (underscore) syntax.

Importance of understanding entity relationships when writing JPA query methods.

How to trace and resolve Spring Data repository errors related to method naming and property resolution.

Ensured database constraints are respected by checking token existence before creating a new one.




